### PR TITLE
買った後の画面遷移を見直しました

### DIFF
--- a/app/controllers/recipe_controller.rb
+++ b/app/controllers/recipe_controller.rb
@@ -50,11 +50,6 @@ class RecipeController < ApplicationController
 
   # 買ったことにするアクション
   def bought
-    if session[:bought] == true
-      redirect_to :action => 'pickup'
-      return
-    end
-
     set_rakuten_api_ids
     category = session[:category]
     recipe_index = session[:recipe_index]
@@ -82,7 +77,6 @@ class RecipeController < ApplicationController
 
     render action: :pickup
     return
-
   end
 
   # Sample for scrape

--- a/app/controllers/recipe_controller.rb
+++ b/app/controllers/recipe_controller.rb
@@ -22,8 +22,6 @@ class RecipeController < ApplicationController
     menus = RakutenWebService::Recipe.ranking(category)
     menu_array = menus.entries
 
-    @bought = session[:bought]
-
     #レシピのランダム化
     @recipe_index = rand(0..3)
     session[:recipe_index] = @recipe_index
@@ -57,8 +55,6 @@ class RecipeController < ApplicationController
       return
     end
 
-    session[:bought] = true
-
     set_rakuten_api_ids
     category = session[:category]
     recipe_index = session[:recipe_index]
@@ -81,8 +77,10 @@ class RecipeController < ApplicationController
     # @todo Cookieに保存するデータ構造の検討
     cookies.permanent[:bought_list] = [serial_time, bought_items]
 
-    # @todo 画面遷移の検討
-    redirect_to :action => 'pickup'
+    # 買ったことにする
+    @bought = true
+
+    render action: :pickup
     return
 
   end


### PR DESCRIPTION
以下変更です。
* `redirect_to` ではなく `render` で `pickup` のコントローラーを使わずに、ビューのみを変更するようにした。
 * 保存後にレシピが変わらないようになる
* 買ったことにする状態をセッションに入れる必要がなくなったので、そのまま変数に設定
 * レシピをチェンジしたら、また保存できるようになる