### PR TITLE
Avoid 500 error

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -2,8 +2,10 @@ class TopController < ApplicationController
 
   def index
     if cookies.permanent['veg_saved'] then
+      @veg_saved = true
       @vegetable_stocks = get_vegetable_stocks cookies
     else
+      @veg_saved = false
       # make rundum data
       @vegetable_stocks = Array.new
       vagetable_list = Constants::VEGETABLE_LIST

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,8 +1,10 @@
   <div class="top_page">
     <ul class="nav nav-pills pull-right">
-      <li class="active" id="bought_button">
-        <%= link_to '使う野菜リスト', 'bought_list' %>
-      </li>
+      <% if @veg_saved == true %>
+        <li class="active" id="bought_button">
+          <%= link_to '使う野菜リスト', 'bought_list' %>
+        </li>
+      <% end %>
       <li class="active">
         <%= link_to '野菜登録する', 'add_vegetables',:style=>"color:#ffffff;" %>
       </li>


### PR DESCRIPTION
Topページからの野菜リストは、Cookieのデータがないと動かないので500になる対応

※ただ、現在、買ったものリストのCookieを見ている