### PR TITLE
全種類の野菜が0より多い時にチャートが0から始まらないのを修正

### DIFF
--- a/app/assets/javascripts/top.coffee
+++ b/app/assets/javascripts/top.coffee
@@ -89,4 +89,5 @@ check_celebrate = ->
     options:
       scale:
         ticks:
+          min: 0, 
           suggestedMax: 5)


### PR DESCRIPTION
https://trello.com/c/pqMlSime
この修正です。
**修正前**
![before_fix](https://cloud.githubusercontent.com/assets/594586/20392515/87d5ddbe-ad1b-11e6-8133-a3fc368ebe90.png)
**修正後**
![after_fix](https://cloud.githubusercontent.com/assets/594586/20392519/8ab5d138-ad1b-11e6-8312-a9506db2f0fd.png)
- 参考
   - http://www.chartjs.org/docs/#scales-radial-linear-scale