### PR TITLE
野菜の数が空の場合の修正

### DIFF
--- a/app/assets/javascripts/top.coffee
+++ b/app/assets/javascripts/top.coffee
@@ -39,7 +39,11 @@ check_celebrate = ->
   miss_match = false
   for veg_name, i in veg_list
     current_veg_count = parseFloat(myChart.data.datasets[0].data[i])
+    if isNaN(current_veg_count)
+      current_veg_count = 0
     will_veg_count = parseFloat(myChart.data.datasets[1].data[i])
+    if isNaN(will_veg_count)
+      will_veg_count = 0
     if will_veg_count == current_veg_count
       if will_veg_count != 0
         match_count = match_count + 1

--- a/app/assets/javascripts/top.coffee
+++ b/app/assets/javascripts/top.coffee
@@ -51,7 +51,8 @@ check_celebrate = ->
     will_veg_count = parseFloat(myChart.data.datasets[1].data[i])
     if isNaN(will_veg_count)
       will_veg_count = 0
-    if will_veg_count == current_veg_count
+    # 小数点以下1桁目を有効数字として判定
+    if format_froat(will_veg_count, 1) == format_froat(current_veg_count, 1)
       if will_veg_count != 0
         match_count = match_count + 1
     else

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -24,7 +24,7 @@ class TopController < ApplicationController
     veg_list = Array.new
     non_veg_list = Array.new
     for i in 0..4 do
-      if @vegetable_stocks[i][2] != '0' then
+      if @vegetable_stocks[i][2].present? && @vegetable_stocks[i][2] != '0' then
         veg_list.push(@vegetable_stocks[i][0])
       else
         non_veg_list.push(@vegetable_stocks[i][0])

--- a/app/views/recipe/add_vegetables.html.erb
+++ b/app/views/recipe/add_vegetables.html.erb
@@ -21,7 +21,7 @@
     <li><%= image_tag('veg_' + vegetable_stock[0].to_s + '.png', :size => '32x32') %></li>
     <li class="title"><%= vegetable_stock[1] %></li>
     <li>
-       <%= if vegetable_stock[2] != '0' then
+       <%= if vegetable_stock[2].to_f != 0 then
             number_field_tag(vegetable_stock[0], vegetable_stock[2],:min => 0, :step => 0.01)
             else
             number_field_tag(vegetable_stock[0],:min => 0, :step => 0.01)


### PR DESCRIPTION
以下のケースを修正
- 野菜の数が空だった場合に、検索一致の判定がうまくいっていなかった
- 野菜の数が空だった場合に、お祝い用の一致の判定がうまくいっていなかった
- 初期表示（Cookie なし）で 0 が表示されてしまっていた