### PR TITLE
野菜の入力欄が空の場合に最小値と step が使われていなかったのを修正

### DIFF
--- a/app/views/recipe/add_vegetables.html.erb
+++ b/app/views/recipe/add_vegetables.html.erb
@@ -24,7 +24,7 @@
        <%= if vegetable_stock[2].to_f != 0 then
             number_field_tag(vegetable_stock[0], vegetable_stock[2],:min => 0, :step => 0.01)
             else
-            number_field_tag(vegetable_stock[0],:min => 0, :step => 0.01)
+            number_field_tag(vegetable_stock[0], '', :min => 0, :step => 0.01)
             end
         %>
     </li>


### PR DESCRIPTION
`number_field_tag` は第2引数を設定していないと、第3引数も有効にならないみたいです。